### PR TITLE
Updates to error handling & access_token request

### DIFF
--- a/neverbounce.go
+++ b/neverbounce.go
@@ -50,6 +50,7 @@ func (n *NeverBounceCli) GetAccessToken() string {
 	)
 
 	request.SetBasicAuth(n.ApiUsername, n.ApiPassword)
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	client := http.Client{}
 

--- a/responses.go
+++ b/responses.go
@@ -1,13 +1,18 @@
 package neverbounce
 
 type AccessTokenResponse struct {
-	AccessToken string `json:"access_token"`
-	Expires     int    `json:"expires"`
+	AccessToken      string `json:"access_token"`
+	Expires          int    `json:"expires"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
 }
 
 type VerifyEmailResponse struct {
-	Success       bool   `json:"success"`
-	Result        int    `json:"result"`
-	ResultDetails int    `json:"result_details"`
-	Msg           string `json:"msg"`
+	Success          bool   `json:"success"`
+	Result           int    `json:"result"`
+	ResultDetails    int    `json:"result_details"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	ErrorMsg         string `json:"error_msg"`
+	Msg              string `json:"msg"`
 }


### PR DESCRIPTION
Mike from NeverBounce here. We did some investigating and found the source of the 400 error with our updates we pushed today. The new version of our software isn't liking requests without a Content-Type defined.

Go's `http.newRequest` doesn't set a Content-Type on its own so we need to explicitly set it with the `http.Head.Add` method. The `http.postForm` does set the proper Content-Type header, so no change is needed there.

In addition to the Content-Type header, I've added some additional error checking. The 400 requests you were receiving earlier had some additional information in the body of the response but never got displayed. These messages will now bubble up and display the message.